### PR TITLE
Fixed #143. BSP16SCM52D last name added.

### DIFF
--- a/d.java
+++ b/d.java
@@ -9,3 +9,4 @@ DSP16SCM29C
 Last Name Added
 
 BSP16SCM52D
+


### PR DESCRIPTION
The number of issue fixed should be #143, not #104. That was for phase I.